### PR TITLE
IAL2 billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This script will create one pdf partner billing report for each production application listed in the 
 service_providers.yml file.  The files will be created in the specified destination directory.  
 
-`Usage:  ruby  main.rb  destination_dir  year  month  monthly_auths.json  service_providers.yml`
+`Usage:  ruby  main.rb  destination_dir  year  month  service_providers.yml monthly_auths.json  active_users.json`
 
 ![billing-report-1](https://user-images.githubusercontent.com/34244063/74994013-d7863080-541a-11ea-84b7-1b0975ec8cb7.png)

--- a/main.rb
+++ b/main.rb
@@ -1,8 +1,8 @@
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'billing_reporter'
 
-if ARGV.length != 5
-  puts "Usage: ruby main.rb destination_directory year month total_monthly_auths.json sp.yml"
+if ARGV.length != 6
+  puts "Usage: ruby main.rb destination_dir year month sp.yml monthly_auths.json active_users.json"
   exit
 end
 
@@ -10,6 +10,7 @@ BillingReporter::GenerateReports.new.call(
   dest_dir: ARGV[0],
   year: ARGV[1].to_i,
   month: ARGV[2].to_i,
-  auths_json: ARGV[3],
-  sp_yml: ARGV[4]
+  sp_yml: ARGV[3],
+  auths_json: ARGV[4],
+  active_users_json: ARGV[5]
 )

--- a/spec/fixtures/active_users.json
+++ b/spec/fixtures/active_users.json
@@ -1,0 +1,3 @@
+[
+  { "issuer":"urn:gov:login:test-providers:fake-prod-sp", "total_ial1_active": 10, "total_ial2_active": 20 }
+]

--- a/spec/integration/billing_reporter_spec.rb
+++ b/spec/integration/billing_reporter_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe BillingReporter::GenerateReports do
           dest_dir: '.',
           year: 2020,
           month: 1,
-          auths_json: 'spec/fixtures/total_monthly_auths.json',
           sp_yml: 'spec/fixtures/service_providers.yml',
+          auths_json: 'spec/fixtures/total_monthly_auths.json',
+          active_users_json: 'spec/fixtures/total_monthly_auths.json',
           )
       confirm_exists_and_unlink(
           'billing-report.test agency 1.urn-gov-login-test-providers-fake-prod-sp.pdf',


### PR DESCRIPTION
**How**: Add an entry for total unique IAL2s for the fiscal year (total proofed users).  Add a new parameter to the report invocation which is the feed for fiscal active users report  https://github.com/18F/identity-idp/pull/3612